### PR TITLE
refactor handler instrumentation using a new metrics wrapper handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # workit
-Golang worker kit for microservice background jobs
+
+This package provides some shared code for our Golang microservice background
+jobs. The project name `workit` means as much as "worker kit". The main concept
+here are **worker handlers**, which are executed concurrently within their own
+isolated failure domain.
+
+```golang
+// Interface describes asynchronous worker handlers that are executed
+// iteratively by a custom task engine. New worker handlers can be created by
+// implementing this handler interface and registering the handler instance with
+// the respective worker engine.
+type Interface interface {
+	// Cooler is the amount of time that any given handler specifies to wait
+	// before being executed again. This is not an interval on a strict schedule.
+	// This is simply the time to sleep after execution, before another cycle
+	// repeats.
+	Cooler() time.Duration
+
+	// Ensure executes the handler specific business logic in order to complete
+	// the given task, if possible. Any error returned will be emitted using the
+	// underlying logger interface. Calling this method will not interfere with
+	// the execution of other handlers, because every handler is managed within
+	// its own pipeline to guarantee isolated failure domains.
+	Ensure() error
+}
+```

--- a/handler/metrics/cooler.go
+++ b/handler/metrics/cooler.go
@@ -1,0 +1,10 @@
+package metrics
+
+import "time"
+
+// Cooler only forwards the cooler of the wrapped handler implementation. That
+// means the metrics handler does not have its own cooler setting, but only acts
+// as proxy for the underlying handler.
+func (m *Metrics) Cooler() time.Duration {
+	return m.han.Cooler()
+}

--- a/handler/metrics/ensure.go
+++ b/handler/metrics/ensure.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/xh3b4sd/tracer"
+)
+
+// Ensure tracks the start time of its own execution and runs the business logic
+// of the wrapped worker handler. The wrapped business logic is instrumented for
+// runtime latency and error rates. Note that Ensure emits debug logs about the
+// internal worker handler execution. Any error returned originates from the
+// underlying handler implementation.
+func (m *Metrics) Ensure() error {
+	// Record the start time for our handler latency. The timezone of the duration
+	// measurement is irrelavant here, so we are not using time.Now().UTC() as a
+	// best practice like we would in other places.
+
+	var sta time.Time
+	{
+		sta = time.Now()
+	}
+
+	// Note that we cannot return the error from the handler execution, because we
+	// want to monitor the failure latency as well, if possible. So instead of
+	// returning the error early during the error case, we simply log the error
+	// and continue below.
+
+	var err error
+	{
+		err = m.han.Ensure()
+	}
+
+	// Record the handler latency immediately after the handler execution. The
+	// function call below must instrument the given handler latency or panic,
+	// which may only happen in case of registry whitelist failures. If this
+	// instrumentation succeeded once, it may never fail again during runtime.
+
+	{
+		m.musIns(sta, err)
+	}
+
+	return tracer.Mask(err)
+}
+
+func (m *Metrics) musIns(sta time.Time, err error) {
+	var lat time.Duration
+	var suc string
+	{
+		lat = time.Since(sta)
+		suc = strconv.FormatBool(err == nil)
+	}
+
+	m.log.Log(
+		"level", "debug",
+		"message", "executed worker handler",
+		"handler", m.nam,
+		"latency", lat.String(),
+		"success", suc,
+	)
+
+	lab := map[string]string{
+		"handler": m.nam,
+		"success": suc,
+	}
+
+	err = m.reg.Counter(MetricTotal, 1, lab)
+	if err != nil {
+		tracer.Panic(tracer.Mask(err))
+	}
+
+	err = m.reg.Histogram(MetricDuration, lat.Seconds(), lab)
+	if err != nil {
+		tracer.Panic(tracer.Mask(err))
+	}
+}

--- a/handler/metrics/handler.go
+++ b/handler/metrics/handler.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/0xSplits/otelgo/registry"
+	"github.com/0xSplits/workit/handler"
+	"github.com/xh3b4sd/logger"
+	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	MetricTotal    = "worker_handler_execution_total"
+	MetricDuration = "worker_handler_execution_duration_seconds"
+)
+
+type Config struct {
+	Env string
+	Han handler.Interface
+	Log logger.Interface
+	Met metric.Meter
+}
+
+type Metrics struct {
+	han handler.Interface
+	log logger.Interface
+	nam string
+	reg registry.Interface
+}
+
+func New(c Config) *Metrics {
+	if c.Han == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Han must not be empty", c)))
+	}
+	if c.Log == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
+	}
+	if c.Met == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Met must not be empty", c)))
+	}
+
+	var nam string
+	{
+		nam = handler.Name(c.Han)
+	}
+
+	var reg registry.Interface
+	{
+		reg = newRegistry(c.Env, c.Log, c.Met, nam)
+	}
+
+	return &Metrics{
+		han: c.Han,
+		log: c.Log,
+		nam: nam,
+		reg: reg,
+	}
+}

--- a/handler/metrics/registry.go
+++ b/handler/metrics/registry.go
@@ -1,0 +1,62 @@
+package metrics
+
+import (
+	"github.com/0xSplits/otelgo/recorder"
+	"github.com/0xSplits/otelgo/registry"
+	"github.com/xh3b4sd/logger"
+	"go.opentelemetry.io/otel/metric"
+)
+
+func newRegistry(env string, log logger.Interface, met metric.Meter, nam string) registry.Interface {
+	cou := map[string]recorder.Interface{}
+
+	{
+		cou[MetricTotal] = recorder.NewCounter(recorder.CounterConfig{
+			Des: "the total amount of worker handler executions",
+			Lab: map[string][]string{
+				"handler": {nam},
+				"success": {"true", "false"},
+			},
+			Met: met,
+			Nam: MetricTotal,
+		})
+	}
+
+	gau := map[string]recorder.Interface{}
+
+	his := map[string]recorder.Interface{}
+
+	{
+		his[MetricDuration] = recorder.NewHistogram(recorder.HistogramConfig{
+			Des: "the time it takes for worker handler executions to complete",
+			Lab: map[string][]string{
+				"handler": {nam},
+				"success": {"true", "false"},
+			},
+			Buc: []float64{
+				0.10, //  100 ms
+				0.15, //  150 ms
+				0.20, //  200 ms
+				0.25, //  250 ms
+				0.50, //  500 ms
+
+				1.00, // 1000 ms
+				1.50, // 1500 ms
+				2.00, // 2000 ms
+				2.50, // 2500 ms
+				5.00, // 5000 ms
+			},
+			Met: met,
+			Nam: MetricDuration,
+		})
+	}
+
+	return registry.New(registry.Config{
+		Env: env,
+		Log: log,
+
+		Cou: cou,
+		Gau: gau,
+		His: his,
+	})
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -5,25 +5,32 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/0xSplits/otelgo/recorder"
-	"github.com/0xSplits/otelgo/registry"
 	"github.com/0xSplits/workit/handler"
+	"github.com/0xSplits/workit/handler/metrics"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
 	"go.opentelemetry.io/otel/metric"
 )
 
-const (
-	MetricTotal    = "worker_handler_execution_total"
-	MetricDuration = "worker_handler_execution_duration_seconds"
-)
-
 type Config struct {
+	// Env is the environment identifier injected to the internally managed
+	// registry interface to annotate all metrics with the respective label, e.g.
+	// "env=staging".
 	Env string
-	// Han are the worker specific handlers implementing the actual business
-	// logic.
+
+	// Han is the list of worker handlers implementing the actual business logic.
+	// The worker handlers configured here may be wrapped in administrative
+	// handler implementations to e.g. instrument handler execution latency and
+	// handler error rates.
 	Han []handler.Interface
+
+	// Log is a standard logger interface to forward structured log messages to
+	// any output interface e.g. stdout.
 	Log logger.Interface
+
+	// Met is the open telemetry meter interface injected to the internally
+	// managed registry interface. This meter will record all worker handler
+	// execution metrics.
 	Met metric.Meter
 }
 
@@ -31,7 +38,6 @@ type Worker struct {
 	han []handler.Interface
 	log logger.Interface
 	rdy chan struct{}
-	reg registry.Interface
 }
 
 func New(c Config) *Worker {
@@ -48,52 +54,18 @@ func New(c Config) *Worker {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Met must not be empty", c)))
 	}
 
-	var nam []string
-	{
-		nam = handler.Names(c.Han)
-	}
+	// Wrap the list of injected worker handlers into their own metrics handler,
+	// so that we can instrument the runtime latency and error rates of every
+	// single worker handler provided.
 
-	cou := map[string]recorder.Interface{}
-
-	{
-		cou[MetricTotal] = recorder.NewCounter(recorder.CounterConfig{
-			Des: "the total amount of worker handler executions",
-			Lab: map[string][]string{
-				"handler": nam,
-				"success": {"true", "false"},
-			},
+	var han []handler.Interface
+	for _, x := range c.Han {
+		han = append(han, metrics.New(metrics.Config{
+			Env: c.Env,
+			Han: x,
+			Log: c.Log,
 			Met: c.Met,
-			Nam: MetricTotal,
-		})
-	}
-
-	gau := map[string]recorder.Interface{}
-
-	his := map[string]recorder.Interface{}
-
-	{
-		his[MetricDuration] = recorder.NewHistogram(recorder.HistogramConfig{
-			Des: "the time it takes for worker handler executions to complete",
-			Lab: map[string][]string{
-				"handler": nam,
-				"success": {"true", "false"},
-			},
-			Buc: []float64{
-				0.10, //  100 ms
-				0.15, //  150 ms
-				0.20, //  200 ms
-				0.25, //  250 ms
-				0.50, //  500 ms
-
-				1.00, // 1000 ms
-				1.50, // 1500 ms
-				2.00, // 2000 ms
-				2.50, // 2500 ms
-				5.00, // 5000 ms
-			},
-			Met: c.Met,
-			Nam: MetricDuration,
-		})
+		}))
 	}
 
 	var rdy chan struct{}
@@ -101,23 +73,10 @@ func New(c Config) *Worker {
 		rdy = make(chan struct{})
 	}
 
-	var reg registry.Interface
-	{
-		reg = registry.New(registry.Config{
-			Env: c.Env,
-			Log: c.Log,
-
-			Cou: cou,
-			Gau: gau,
-			His: his,
-		})
-	}
-
 	return &Worker{
-		han: c.Han,
+		han: han,
 		log: c.Log,
 		rdy: rdy,
-		reg: reg,
 	}
 }
 
@@ -138,7 +97,7 @@ func (w *Worker) Daemon() {
 		go w.daemon(h)
 	}
 
-	// Signal the worker daemon's readiness by closing the internal ready channel.
+	// Signal the worker engine's readiness by closing the internal ready channel.
 	// This mechanism implies that Worker.Daemon() must never be called twice,
 	// because closing a closed channel results in a runtime panic. Time based
 	// systems are often a source of race conditions. Providing this mechanism may
@@ -161,7 +120,11 @@ func (w *Worker) Daemon() {
 
 func (w *Worker) daemon(han handler.Interface) {
 	for {
-		err := w.ensure(han)
+		// Execute the worker handler and log any runtime error of this handler's
+		// business logic. Note that any error caught here may not originate from
+		// the worker engine's internal metric registry.
+
+		err := han.Ensure()
 		if err != nil {
 			w.error(err)
 		}
@@ -174,74 +137,6 @@ func (w *Worker) daemon(han handler.Interface) {
 			time.Sleep(han.Cooler())
 		}
 	}
-}
-
-func (w *Worker) ensure(han handler.Interface) error {
-	// Record the start time for our handler latency. The timezone of the duration
-	// measurement is irrelavant here, so we are not using time.Now().UTC() as a
-	// best practice like we would in other places.
-
-	var sta time.Time
-	{
-		sta = time.Now()
-	}
-
-	// Note that we cannot return the error from the handler execution, because we
-	// want to monitor the failure latency as well, if possible. So instead of
-	// returning the error early during the error case, we simply log the error
-	// and continue below.
-
-	var err error
-	{
-		err = han.Ensure()
-		if err != nil {
-			w.error(err)
-		}
-	}
-
-	// Record the handler latency immediately after the handler execution. Here as
-	// well, time.Since() does not rely on a specific timezone, so we can simply
-	// use the time.Now() instance of this cycle's start time.
-
-	var lat time.Duration
-	var suc string
-	{
-		lat = time.Since(sta)
-		suc = strconv.FormatBool(err == nil)
-	}
-
-	w.log.Log(
-		"level", "debug",
-		"message", "executed worker handler",
-		"handler", handler.Name(han),
-		"latency", lat.String(),
-		"success", suc,
-	)
-
-	{
-		lab := map[string]string{
-			"success": suc,
-		}
-
-		err := w.reg.Counter(MetricTotal, 1, lab)
-		if err != nil {
-			return tracer.Mask(err)
-		}
-	}
-
-	{
-		lab := map[string]string{
-			"handler": handler.Name(han),
-			"success": suc,
-		}
-
-		err := w.reg.Histogram(MetricDuration, lat.Seconds(), lab)
-		if err != nil {
-			return tracer.Mask(err)
-		}
-	}
-
-	return nil
 }
 
 func (w *Worker) error(err error) {


### PR DESCRIPTION
I wasn't quite happy with the worker engine design, because the code to execute worker handlers was too convoluted for my taste. One clear boundary was the logic around metrics collection, so I pulled this out and put it into its own worker handler. The design principle here is resource wrapping, where one implementation wraps the other, while both implement the same interface.

As a result the worker engine is cleaner and while the metrics handler still has to deal with a bunch of quirks in its own right, everything has its place now. A note about testing. I used this in Specta by setting my local `workit` copy as the active dependency. There is a neat Go command for this in the toolchain.

```
go mod edit -replace=github.com/0xSplits/workit=../workit/
```