### PR TITLE
enable errors as control flow primitive in worker engine

### DIFF
--- a/handler/metrics/ensure.go
+++ b/handler/metrics/ensure.go
@@ -49,7 +49,7 @@ func (m *Metrics) musIns(sta time.Time, err error) {
 	var suc string
 	{
 		lat = time.Since(sta)
-		suc = strconv.FormatBool(err == nil)
+		suc = strconv.FormatBool(err == nil || m.fil(err))
 	}
 
 	m.log.Log(

--- a/handler/metrics/handler.go
+++ b/handler/metrics/handler.go
@@ -17,12 +17,14 @@ const (
 
 type Config struct {
 	Env string
+	Fil func(error) bool
 	Han handler.Interface
 	Log logger.Interface
 	Met metric.Meter
 }
 
 type Metrics struct {
+	fil func(error) bool
 	han handler.Interface
 	log logger.Interface
 	nam string
@@ -30,6 +32,9 @@ type Metrics struct {
 }
 
 func New(c Config) *Metrics {
+	if c.Fil == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Fil must not be empty", c)))
+	}
 	if c.Han == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Han must not be empty", c)))
 	}
@@ -51,6 +56,7 @@ func New(c Config) *Metrics {
 	}
 
 	return &Metrics{
+		fil: c.Fil,
 		han: c.Han,
 		log: c.Log,
 		nam: nam,


### PR DESCRIPTION
With this change we can use specific errors as control flow primitives when cancelling further execution of our workers reconciliation loops without propagating those errors through the worker engine's logs and metrics. This change was tested in https://github.com/0xSplits/kayron/pull/22.