### PR TITLE
allow worker handlers to disable themselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@ here are **worker handlers**, which are executed by soecialized worker engines.
 
 ```golang
 // Interface describes the internally wrapped worker handlers used for proper
-// management inside of the various worker engines. External users do not have
-// to be concerned with this interface.
+// management inside of the various worker engines. External users do usually
+// not have to be concerned with this entire interface.
 type Interface interface {
+	// Active returns the underlying worker handler implementation is supposed to
+	// be executed during reconciliation. This might be useful to disable certain
+	// worker handlers for e.g. specific environments.
+	Active() bool
+
 	// Cooler is manadatory to be implemented for worker handlers executed by the
 	// *parallel.Worker engine, because those worker handlers do all run inside
 	// their own isolated failure domains, which require individual cooler durations

--- a/handler/dummy/active.go
+++ b/handler/dummy/active.go
@@ -1,0 +1,5 @@
+package dummy
+
+func (d *Dummy) Active() bool {
+	return false
+}

--- a/handler/interface.go
+++ b/handler/interface.go
@@ -3,12 +3,21 @@ package handler
 import "time"
 
 // Interface describes the internally wrapped worker handlers used for proper
-// management inside of the various worker engines. External users do not have
-// to be concerned with this interface.
+// management inside of the various worker engines. External users do usually
+// not have to be concerned with this entire interface.
 type Interface interface {
 	Cooler
 	Ensure
 	Unwrap
+}
+
+// Active is a scheduler primitive that allows worker handlers to be disabled
+// for arbitrary conditions.
+type Active interface {
+	// Active returns the underlying worker handler implementation is supposed to
+	// be executed during reconciliation. This might be useful to disable certain
+	// worker handlers for e.g. specific environments.
+	Active() bool
 }
 
 // Cooler is manadatory to be implemented for worker handlers executed by the
@@ -30,6 +39,7 @@ type Cooler interface {
 // implement for their own business logic, regardless of the underlying worker
 // engine.
 type Ensure interface {
+	Active
 	// Ensure executes the handler specific business logic in order to complete
 	// the given task, if possible. Any error returned will be emitted using the
 	// underlying logger interface, unless the injected metrics registry is

--- a/handler/metrics/active.go
+++ b/handler/metrics/active.go
@@ -1,0 +1,8 @@
+package metrics
+
+// Active only forwards the scheduler primitive of the wrapped handler
+// implementation. That means the metrics handler does not have its own
+// activation setting, but only acts as proxy for the underlying handler.
+func (m *Metrics) Active() bool {
+	return m.han.Active()
+}

--- a/handler/proxy/active.go
+++ b/handler/proxy/active.go
@@ -1,0 +1,17 @@
+package proxy
+
+import (
+	"github.com/0xSplits/workit/handler"
+)
+
+// Active returns the scheduler primitive of the underlying worker handler if
+// that handler implements the handler.Active interface. Otherwise true is
+// returned.
+func (p *Proxy) Active() bool {
+	v, i := p.han.(handler.Active)
+	if i {
+		return v.Active()
+	}
+
+	return true
+}

--- a/handler/proxy/cooler_test.go
+++ b/handler/proxy/cooler_test.go
@@ -51,6 +51,10 @@ type testCooler struct {
 	coo time.Duration
 }
 
+func (t *testCooler) Active() bool {
+	return true
+}
+
 func (t *testCooler) Ensure() error {
 	return nil
 }

--- a/handler/proxy/ensure_test.go
+++ b/handler/proxy/ensure_test.go
@@ -2,6 +2,10 @@ package proxy
 
 type testEnsure struct{}
 
+func (t *testEnsure) Active() bool {
+	return true
+}
+
 func (t *testEnsure) Ensure() error {
 	return nil
 }

--- a/handler/proxy/unwrap_test.go
+++ b/handler/proxy/unwrap_test.go
@@ -52,6 +52,10 @@ type testUnwrap struct {
 	wrp handler.Ensure
 }
 
+func (t *testUnwrap) Active() bool {
+	return true
+}
+
 func (t *testUnwrap) Ensure() error {
 	return nil
 }

--- a/testdata/artefact/handler.go
+++ b/testdata/artefact/handler.go
@@ -2,6 +2,10 @@ package artefact
 
 type Handler struct{}
 
+func (h *Handler) Active() bool {
+	return true
+}
+
 func (h *Handler) Ensure() error {
 	return nil
 }

--- a/testdata/metadata/foo.go
+++ b/testdata/metadata/foo.go
@@ -2,6 +2,10 @@ package metadata
 
 type Foo struct{}
 
+func (f *Foo) Active() bool {
+	return false
+}
+
 func (f *Foo) Ensure() error {
 	return nil
 }

--- a/testdata/operator/operator.go
+++ b/testdata/operator/operator.go
@@ -2,6 +2,10 @@ package operator
 
 type Operator struct{}
 
+func (p *Operator) Active() bool {
+	return true
+}
+
 func (o *Operator) Ensure() error {
 	return nil
 }

--- a/worker/parallel/ensure.go
+++ b/worker/parallel/ensure.go
@@ -9,14 +9,16 @@ import (
 
 func (w *Worker) ensure(han handler.Interface) {
 	for {
-		// Execute the worker handler and log any runtime error of this handler's
-		// business logic if the configured error matcher permits it. Note that any
-		// error caught here may never originate from the worker engine's internal
-		// metric registry.
+		// Execute the worker handler if it declares itself to be active. Also log
+		// any runtime error of this handler's business logic if the configured
+		// error matcher permits it. Note that any error caught here may never
+		// originate from the worker engine's internal metric registry.
 
-		err := han.Ensure()
-		if err != nil && !w.reg.Log(err) {
-			w.error(tracer.Mask(err, tracer.Context{Key: "handler", Value: handler.Name(han.Unwrap())}))
+		if han.Active() {
+			err := han.Ensure()
+			if err != nil && !w.reg.Log(err) {
+				w.error(tracer.Mask(err, tracer.Context{Key: "handler", Value: handler.Name(han.Unwrap())}))
+			}
 		}
 
 		// Sleep for the given duration after this worker handler has been executed.

--- a/worker/sequence/ensure.go
+++ b/worker/sequence/ensure.go
@@ -42,6 +42,14 @@ func (w *Worker) ensPar(han []handler.Interface) error {
 	// iteration.
 
 	for _, x := range han {
+		// Continue with the next worker handler without doing any work for this
+		// specific worker handler if this worker handler declares itself as not
+		// active for this reconciliation loop.
+
+		if !x.Active() {
+			continue
+		}
+
 		grp.Go(func() error {
 			// Note that our worker handlers may be wrapped. So we have to call unwrap
 			// before resolving the implementation's identifier in the error case.
@@ -69,6 +77,13 @@ func (w *Worker) ensSeq(han []handler.Interface) error {
 	var x handler.Interface
 	{
 		x = han[0] // the factory at sequence.New must validate against empty steps
+	}
+
+	// Return early without doing any work if this worker handler declares itself
+	// as not active for this reconciliation loop.
+
+	if !x.Active() {
+		return nil
 	}
 
 	// Note that our worker handlers may be wrapped. So we have to call unwrap


### PR DESCRIPTION
Towards https://linear.app/splits/issue/PE-4788/support-vercel-like-preview-deployments. This new option of the worker handler interface allows worker handlers to be deactivated based on their own logic. E.g. for preview deployments we are using this to disable a specific worker handler in `staging` and `production` environments, so that we only enable preview deployments in `testing`.

There are unit tests for both the `parallel` and `sequence` worker engines. This also got tested with the Kayron operator integration test.